### PR TITLE
Fix misspelled reference to field name

### DIFF
--- a/src/mongoLog.js
+++ b/src/mongoLog.js
@@ -149,7 +149,7 @@ export default async function (MONGO_URI) {
           {
             $set: {
               modificationTime: moment().toDate(),
-              protect: {$not: '$protect'}
+              protected: {$not: '$protected'}
             }
           }
         ]


### PR DESCRIPTION
- Fix misspelled reference to logItem field name "protected"